### PR TITLE
Update checker.rb to automatically lowercase hashes for crypto lib compatibility

### DIFF
--- a/lib/restful_api_authentication/checker.rb
+++ b/lib/restful_api_authentication/checker.rb
@@ -39,7 +39,7 @@ module RestfulApiAuthentication
       return_val = false
       if headers_have_values?
         if in_time_window?
-          if test_hash == @http_headers[@@header_signature]
+          if test_hash.downcase == @http_headers[@@header_signature].downcase
             if options[:require_master] == true
               if is_master?
                 return_val = true


### PR DESCRIPTION
Automatic lower-casing of submitted (and generated) signature hash. 
Many libs automatically uppercase (cryptocpp for example) uppercase SHA256 hashes, resulting in manual lowercasing before submission.
